### PR TITLE
Fix sending blank requests to the wrong API

### DIFF
--- a/src/Generic/AbstractRequest.php
+++ b/src/Generic/AbstractRequest.php
@@ -41,7 +41,7 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
 
     public function getEndpoint()
     {
-        if ($this->getTestMode()) {
+        if (!$this->getTestMode()) {
             return self::LIVE_ENDPOINT;
         }
 
@@ -54,10 +54,9 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
             'Accept' => 'application/json',
             'Content-Type' => 'application/json;charset=UTF-8',
             'Authorization' => $this->getSecretKey()
-        ], empty($data) ? json_encode($data) : null);
+        ], empty($data) ? null : json_encode($data));
 
         $result = json_decode($response->getBody()->getContents(), true);
-
         return $result;
     }
 }


### PR DESCRIPTION
Prior to this change, when running in test mode, the requests would get sent to the `LIVE_ENDPOINT`. The requests would also have a blank body because `empty($data)` would return false and thus return the `null` part of the ternary.